### PR TITLE
Add support for GopherJS build target

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,7 +2,6 @@
 package gls
 
 import (
-	"runtime"
 	"sync"
 )
 
@@ -19,11 +18,6 @@ var (
 // Values is simply a map of key types to value types. Used by SetValues to
 // set multiple values at once.
 type Values map[interface{}]interface{}
-
-func currentStack(skip int) []uintptr {
-	stack := make([]uintptr, maxCallers)
-	return stack[:runtime.Callers(2+skip, stack)]
-}
 
 // ContextManager is the main entrypoint for interacting with
 // Goroutine-local-storage. You can have multiple independent ContextManagers
@@ -68,7 +62,7 @@ func (m *ContextManager) SetValues(new_values Values, context_call func()) {
 		return
 	}
 
-	tags := readStackTags(currentStack(1))
+	tags := readStackTags(1)
 
 	m.mtx.Lock()
 	values := new_values
@@ -103,7 +97,7 @@ func (m *ContextManager) SetValues(new_values Values, context_call func()) {
 // will be false.
 func (m *ContextManager) GetValue(key interface{}) (value interface{}, ok bool) {
 
-	tags := readStackTags(currentStack(1))
+	tags := readStackTags(1)
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 	for _, tag := range tags {
@@ -116,7 +110,7 @@ func (m *ContextManager) GetValue(key interface{}) (value interface{}, ok bool) 
 }
 
 func (m *ContextManager) getValues() Values {
-	tags := readStackTags(currentStack(2))
+	tags := readStackTags(2)
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 	for _, tag := range tags {

--- a/stack_tags.go
+++ b/stack_tags.go
@@ -73,7 +73,13 @@ func _m(tag_remainder uint, cb func()) {
 	}
 }
 
-func readStackTags(stack []uintptr) (tags []uint) {
+func currentStack(skip int) []uintptr {
+	stack := make([]uintptr, maxCallers)
+	return stack[:runtime.Callers(3+skip, stack)]
+}
+
+func readStackTags(skip int) (tags []uint) {
+	stack := currentStack(skip)
 	var current_tag uint
 	for _, pc := range stack {
 		pc = runtime.FuncForPC(pc).Entry()

--- a/stack_tags.go
+++ b/stack_tags.go
@@ -1,13 +1,6 @@
-// +build !js
-
 package gls
 
 // so, basically, we're going to encode integer tags in base-16 on the stack
-
-import (
-	"reflect"
-	"runtime"
-)
 
 const (
 	bitWidth = 4
@@ -41,61 +34,10 @@ func markF(tag uint, cb func()) { _m(tag, cb) }
 var pc_lookup = make(map[uintptr]int8, 17)
 var mark_lookup [16]func(uint, func())
 
-func init() {
-	setEntries := func(f func(uint, func()), v int8) {
-		pc_lookup[reflect.ValueOf(f).Pointer()] = v
-		if v >= 0 {
-			mark_lookup[v] = f
-		}
-	}
-	setEntries(markS, -0x1)
-	setEntries(mark0, 0x0)
-	setEntries(mark1, 0x1)
-	setEntries(mark2, 0x2)
-	setEntries(mark3, 0x3)
-	setEntries(mark4, 0x4)
-	setEntries(mark5, 0x5)
-	setEntries(mark6, 0x6)
-	setEntries(mark7, 0x7)
-	setEntries(mark8, 0x8)
-	setEntries(mark9, 0x9)
-	setEntries(markA, 0xa)
-	setEntries(markB, 0xb)
-	setEntries(markC, 0xc)
-	setEntries(markD, 0xd)
-	setEntries(markE, 0xe)
-	setEntries(markF, 0xf)
-}
-
 func _m(tag_remainder uint, cb func()) {
 	if tag_remainder == 0 {
 		cb()
 	} else {
 		mark_lookup[tag_remainder&0xf](tag_remainder>>bitWidth, cb)
 	}
-}
-
-func currentStack(skip int) []uintptr {
-	stack := make([]uintptr, maxCallers)
-	return stack[:runtime.Callers(3+skip, stack)]
-}
-
-func readStackTags(skip int) (tags []uint) {
-	stack := currentStack(skip)
-	var current_tag uint
-	for _, pc := range stack {
-		pc = runtime.FuncForPC(pc).Entry()
-		val, ok := pc_lookup[pc]
-		if !ok {
-			continue
-		}
-		if val < 0 {
-			tags = append(tags, current_tag)
-			current_tag = 0
-			continue
-		}
-		current_tag <<= bitWidth
-		current_tag += uint(val)
-	}
-	return
 }

--- a/stack_tags_js.go
+++ b/stack_tags_js.go
@@ -12,38 +12,6 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 )
 
-const (
-	bitWidth = 4
-)
-
-func addStackTag(tag uint, context_call func()) {
-	if context_call == nil {
-		return
-	}
-	markS(tag, context_call)
-}
-
-func markS(tag uint, cb func()) { _m(tag, cb) }
-func mark0(tag uint, cb func()) { _m(tag, cb) }
-func mark1(tag uint, cb func()) { _m(tag, cb) }
-func mark2(tag uint, cb func()) { _m(tag, cb) }
-func mark3(tag uint, cb func()) { _m(tag, cb) }
-func mark4(tag uint, cb func()) { _m(tag, cb) }
-func mark5(tag uint, cb func()) { _m(tag, cb) }
-func mark6(tag uint, cb func()) { _m(tag, cb) }
-func mark7(tag uint, cb func()) { _m(tag, cb) }
-func mark8(tag uint, cb func()) { _m(tag, cb) }
-func mark9(tag uint, cb func()) { _m(tag, cb) }
-func markA(tag uint, cb func()) { _m(tag, cb) }
-func markB(tag uint, cb func()) { _m(tag, cb) }
-func markC(tag uint, cb func()) { _m(tag, cb) }
-func markD(tag uint, cb func()) { _m(tag, cb) }
-func markE(tag uint, cb func()) { _m(tag, cb) }
-func markF(tag uint, cb func()) { _m(tag, cb) }
-
-var pc_lookup = make(map[uintptr]int8, 17)
-var mark_lookup [16]func(uint, func())
-
 var stackRE = regexp.MustCompile("\\s+at (\\S*) \\([^:]+:(\\d+):(\\d+)")
 
 func findPtr() uintptr {
@@ -94,14 +62,6 @@ func init() {
 	setEntries(markD, 0xd)
 	setEntries(markE, 0xe)
 	setEntries(markF, 0xf)
-}
-
-func _m(tag_remainder uint, cb func()) {
-	if tag_remainder == 0 {
-		cb()
-	} else {
-		mark_lookup[tag_remainder&0xf](tag_remainder>>bitWidth, cb)
-	}
 }
 
 func currentStack(skip int) (stack []uintptr) {

--- a/stack_tags_main.go
+++ b/stack_tags_main.go
@@ -1,0 +1,61 @@
+// +build !js
+
+package gls
+
+// This file is used for standard Go builds, which have the expected runtime support
+
+import (
+	"reflect"
+	"runtime"
+)
+
+func init() {
+	setEntries := func(f func(uint, func()), v int8) {
+		pc_lookup[reflect.ValueOf(f).Pointer()] = v
+		if v >= 0 {
+			mark_lookup[v] = f
+		}
+	}
+	setEntries(markS, -0x1)
+	setEntries(mark0, 0x0)
+	setEntries(mark1, 0x1)
+	setEntries(mark2, 0x2)
+	setEntries(mark3, 0x3)
+	setEntries(mark4, 0x4)
+	setEntries(mark5, 0x5)
+	setEntries(mark6, 0x6)
+	setEntries(mark7, 0x7)
+	setEntries(mark8, 0x8)
+	setEntries(mark9, 0x9)
+	setEntries(markA, 0xa)
+	setEntries(markB, 0xb)
+	setEntries(markC, 0xc)
+	setEntries(markD, 0xd)
+	setEntries(markE, 0xe)
+	setEntries(markF, 0xf)
+}
+
+func currentStack(skip int) []uintptr {
+	stack := make([]uintptr, maxCallers)
+	return stack[:runtime.Callers(3+skip, stack)]
+}
+
+func readStackTags(skip int) (tags []uint) {
+	stack := currentStack(skip)
+	var current_tag uint
+	for _, pc := range stack {
+		pc = runtime.FuncForPC(pc).Entry()
+		val, ok := pc_lookup[pc]
+		if !ok {
+			continue
+		}
+		if val < 0 {
+			tags = append(tags, current_tag)
+			current_tag = 0
+			continue
+		}
+		current_tag <<= bitWidth
+		current_tag += uint(val)
+	}
+	return
+}


### PR DESCRIPTION
This PR is motivated by my desire to use [GoConvey](https://github.com/smartystreets/goconvey) to test Go code targeted for [GopherJS](https://github.com/gopherjs/gopherjs). GoConvey depends heavily on this gls, which in turn depends heavily on the native Go [runtime](https://golang.org/pkg/runtime/) package, which is not well supported by GopherJS (for good reason).

This patch uses Node.js runtime information to emulate the Go runtime functionality, when run in a GopherJS environment.  This is untested in the browser, and is actually quite likely to break in non-V8 browsers, due to the fact that stack traces are formatted differently. For my needs, browser support is unimportant, so I didn't worry about this.

The original version of gls fails in GopherJS:

    --- FAIL: TestContexts (0.01s)
            test.044076904:23193: expected value val1c for key key1, got no value
    FAIL

After my changes, all tests pass in both standard go (i.e. `go test`) and in GopherJS (i.e. `gopherjs test`).