### PR TITLE
Enable go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jtolds/gls
+
+require github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
+github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=


### PR DESCRIPTION
https://github.com/golang/go/wiki/Modules#gomod

This PR is just a result of the following commands (in clean Go 1.11.5 environment):

```
go mod init
go get ./...
go mod tidy
```

The aim is to prevent `gls` from being marked as "incompatible" in go-mod-aware modules which depend on gls. This happens just because gls is `>1.0.0` (currently `v4.20`) but isn't go-mod-aware. See https://forum.golangbridge.org/t/go-get-marking-go-mod-incompatible/10686 for more.