### PR TITLE
remove mutex lock in a goroutine lifecycle

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -124,22 +124,34 @@ func ExampleGo() {
 
 func BenchmarkGetValue(b *testing.B) {
 	mgr := gls.NewContextManager()
+	wg := sync.WaitGroup{}
 	mgr.SetValues(gls.Values{"test_key": "test_val"}, func() {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			val, ok := mgr.GetValue("test_key")
-			if !ok || val != "test_val" {
-				b.FailNow()
-			}
+			wg.Add(1)
+			gls.Go(func() {
+				defer wg.Done()
+				val, ok := mgr.GetValue("test_key")
+				if !ok || val != "test_val" {
+					b.FailNow()
+				}
+			})
 		}
+		wg.Wait()
 	})
 }
 
 func BenchmarkSetValues(b *testing.B) {
 	mgr := gls.NewContextManager()
+	wg := sync.WaitGroup{}
 	for i := 0; i < b.N/2; i++ {
-		mgr.SetValues(gls.Values{"test_key": "test_val"}, func() {
-			mgr.SetValues(gls.Values{"test_key2": "test_val2"}, func() {})
-		})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mgr.SetValues(gls.Values{"test_key": "test_val"}, func() {
+				mgr.SetValues(gls.Values{"test_key2": "test_val2"}, func() {})
+			})
+		}()
 	}
+	wg.Wait()
 }

--- a/gid.go
+++ b/gid.go
@@ -4,17 +4,23 @@ var (
 	stackTagPool = &idPool{}
 )
 
+func initIdPool() {
+	stackTagPool.Pool.New = func() interface{} {
+		return stackTagPool.newID()
+	}
+}
+
 // Will return this goroutine's identifier if set. If you always need a
 // goroutine identifier, you should use EnsureGoroutineId which will make one
 // if there isn't one already.
-func GetGoroutineId() (gid uint, ok bool) {
+func GetGoroutineId() (gid uint32, ok bool) {
 	return readStackTag()
 }
 
 // Will call cb with the current goroutine identifier. If one hasn't already
 // been generated, one will be created and set first. The goroutine identifier
 // might be invalid after cb returns.
-func EnsureGoroutineId(cb func(gid uint)) {
+func EnsureGoroutineId(cb func(gid uint32)) {
 	if gid, ok := readStackTag(); ok {
 		cb(gid)
 		return

--- a/stack_tags.go
+++ b/stack_tags.go
@@ -9,11 +9,11 @@ const (
 
 var (
 	pc_lookup   = make(map[uintptr]int8, 17)
-	mark_lookup [16]func(uint, func())
+	mark_lookup [16]func(uint32, func())
 )
 
 func init() {
-	setEntries := func(f func(uint, func()), v int8) {
+	setEntries := func(f func(uint32, func()), v int8) {
 		var ptr uintptr
 		f(0, func() {
 			ptr = findPtr()
@@ -40,9 +40,11 @@ func init() {
 	setEntries(github_com_jtolds_gls_markD, 0xd)
 	setEntries(github_com_jtolds_gls_markE, 0xe)
 	setEntries(github_com_jtolds_gls_markF, 0xf)
+
+	initIdPool()
 }
 
-func addStackTag(tag uint, context_call func()) {
+func addStackTag(tag uint32, context_call func()) {
 	if context_call == nil {
 		return
 	}
@@ -53,57 +55,57 @@ func addStackTag(tag uint, context_call func()) {
 // is easier. it shouldn't add any runtime cost in non-js builds.
 
 //go:noinline
-func github_com_jtolds_gls_markS(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markS(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark0(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark0(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark1(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark1(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark2(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark2(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark3(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark3(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark4(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark4(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark5(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark5(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark6(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark6(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark7(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark7(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark8(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark8(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_mark9(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_mark9(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_markA(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markA(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_markB(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markB(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_markC(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markC(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_markD(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markD(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_markE(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markE(tag uint32, cb func()) { _m(tag, cb) }
 
 //go:noinline
-func github_com_jtolds_gls_markF(tag uint, cb func()) { _m(tag, cb) }
+func github_com_jtolds_gls_markF(tag uint32, cb func()) { _m(tag, cb) }
 
-func _m(tag_remainder uint, cb func()) {
+func _m(tag_remainder uint32, cb func()) {
 	if tag_remainder == 0 {
 		cb()
 	} else {
@@ -111,8 +113,8 @@ func _m(tag_remainder uint, cb func()) {
 	}
 }
 
-func readStackTag() (tag uint, ok bool) {
-	var current_tag uint
+func readStackTag() (tag uint32, ok bool) {
+	var current_tag uint32
 	offset := 0
 	for {
 		batch, next_offset := getStack(offset, stackBatchSize)
@@ -125,7 +127,7 @@ func readStackTag() (tag uint, ok bool) {
 				return current_tag, true
 			}
 			current_tag <<= bitWidth
-			current_tag += uint(val)
+			current_tag += uint32(val)
 		}
 		if next_offset == 0 {
 			break


### PR DESCRIPTION
There is a performance loss due to mutex locks in situations where goroutines are frequently created/exited.

1. I used lock free pool as goroutine id pool.
2. In order to get the "Values" corresponding to the goroutine id, I made it possible to access without contention by using a pre-assigned array instead of map. It is assumed that the array can grow variably and holds write locks only when it needs to be grown.

It was confirmed that there is a significant performance difference by modifying the benchmark test case.
- before
```
BenchmarkGetValue-10    	    2514	    551195 ns/op
BenchmarkSetValues-10    	    6830	    166487 ns/op
```

- after
```
BenchmarkGetValue-10    	    4240	    505839 ns/op
BenchmarkSetValues-10    	   15340	     76396 ns/op
```